### PR TITLE
Refactorización de código

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -64,7 +64,7 @@ const int cadencia1 = 1;
 
 // (True) si se desea activar la posibilidad de acelerar desde parado a
 // 6 km/h arrancando con el freno pulsado.
-const boolean frenopulsado = false;
+const boolean frenopulsado = true;
 
 // Retardo en segundos para parar el motor una vez se deja de pedalear.
 // Usar múltiplos de 0.25 --> 0.25 = 1/4 de segundo.
@@ -99,7 +99,7 @@ float suavidad_autoprogresivos = 5;
 
 // Ideado para evitar posibles falsos positivos de pedal,
 // puede dificultar encontrar la cadencia en cuestas empinadas.
-const boolean cadencia_dinamica_ap = false;
+const boolean cadencia_dinamica_ap = true;
 
 // Dirección del bus I2C [DAC] (0x60) si está soldado, si no (0x62).
 const int dir_dac = 0x60;

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -144,7 +144,7 @@ const float voltaje_minimo = 0.85; // TODO eliminar valor en voltios y utilizar 
 const float minimo_acelerador = 1.15; // TODO eliminar valor en voltios y utilizar a0_low_value
 
 // 6 km/h en el acelerador.
-const float sixkmh_acelerador = 2.19; // TODO eliminar valor en voltios y utilizar a0_6km_value
+// -------------- const float sixkmh_acelerador = 2.19; // TODO eliminar valor en voltios y utilizar a0_6km_value
 
 // Valores mínimos y máximos del acelerador leídos por el pin A0.
 float a0_min_value = 190.0; // Valor por defecto, al inicializar, lee el valor real del acelerador.
@@ -325,10 +325,7 @@ void mandaAcelerador() {
 
 	if (nivel_aceleracion != bkp_voltaje) {
 		bkp_voltaje = nivel_aceleracion;
-		// Ajusta el voltaje a valor entre 0-4096 (Resolución del DAC).
-		uint32_t valor = voltiosEnDac(nivel_aceleracion);
-		// Fija voltaje en DAC.
-		dac.setVoltage(valor,false);
+		dac.setVoltage(voltiosEnDac(nivel_aceleracion),false);
 	}  
 }
 
@@ -358,7 +355,7 @@ void ayudaArranque() {
 		// No queremos iniciar un progresivo si empezamos a pedalear con el acelerador accionado.
 		contador_retardo_inicio_progresivo++;
 		// Mandamos al DAC 6 km/h.
-		dac.setVoltage(voltiosEnDac(sixkmh_acelerador),false);
+		dac.setVoltage(aceleradorEnDac(a0_6km_value),false);
 	}
 
 	// Dejamos de asistir en el DAC.
@@ -390,7 +387,7 @@ void validaMinAcelerador() {
 
 void setup() {
 	dac.begin(dir_dac); // Configura DAC.
-	dac.setVoltage(810,false); // Fija voltaje inicial en Dac (0.85v).
+	dac.setVoltage(aceleradorEnDac(a0_min_value),false); // Fija voltaje inicial en Dac (0.85v).
 
 	// Configura pines y prepara las interrupciones.
 	pinMode(pin_piezo,OUTPUT);

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -83,7 +83,9 @@ const boolean freno_anula_crucero = false;
 // Nivel al que se desea iniciar el progresivo.
 // Aumentar si se desea salir con mas tirón.
 // >> NO PASAR DE 2.00, NI BAJAR DE 0.85 <<.
-float nivel_inicial_progresivo = 1.5;
+float nivel_inicial_progresivo = 1.5; // TODO eliminar valor en voltios y utilizar a0_forward_init_value
+// >> NO PASAR DE 410, NI BAJAR DE 190 <<.
+float a0_forward_init_value = 306; // 1.5 (190 -> 410)
 
 // Retardo para inciar progresivo tras parar pedales.
 // Freno anula el tiempo.
@@ -133,16 +135,16 @@ const int tiempo_cadencia = 250;
 // Voltios máximos que da el acelerador, subir si se nota falta de 
 // potencia, bajar si para el motor a tope o se producen ruidos raros.
 // No pasar de 4.20.
-const float v_max_acelerador = 3.90;
+const float v_max_acelerador = 3.90; // TODO eliminar valor en voltios y utilizar a0_high_value
 
 // Voltaje mínimo de acelerador en reposo.
-const float voltaje_minimo = 0.85;
+const float voltaje_minimo = 0.85; // TODO eliminar valor en voltios y utilizar a0_min_value
 
 // Valor mínimo del acelerador para evitar fallos por picos.
-const float minimo_acelerador = 1.15;
+const float minimo_acelerador = 1.15; // TODO eliminar valor en voltios y utilizar a0_low_value
 
 // 6 km/h en el acelerador.
-const float sixkmh_acelerador = 2.19;
+const float sixkmh_acelerador = 2.19; // TODO eliminar valor en voltios y utilizar a0_6km_value
 
 // Valores mínimos y máximos del acelerador leídos por el pin A0.
 float a0_min_value = 190.0; // Valor por defecto, al inicializar, lee el valor real del acelerador.

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -146,9 +146,10 @@ const float sixkmh_acelerador = 2.19;
 
 // Valores mínimos y máximos del acelerador leídos por el pin A0.
 float a0_min_value = 190.0; // Valor por defecto, al inicializar, lee el valor real del acelerador.
-const float a0_6km_value = 450.0;
-const float a0_med_value = 550.0;
-const float a0_max_value = 847.0;
+const float a0_low_value = 235.0;  // 1.15
+const float a0_6km_value = 450.0;  // 2.19
+const float a0_med_value = 550.0;  // 2.68
+const float a0_high_value = 847.0; // 4.13
 
 // Variables para millis().
 unsigned long tcadencia;
@@ -282,8 +283,8 @@ float nivelaAcelerador(float n_acelerador) {
   // Nivelamos los valores para que no salgan del rango de máximo/mínimo.
   if (n_acelerador <= a0_min_value) {
     return a0_min_value;
-  } else if (n_acelerador >= a0_max_value) {
-    return a0_max_value;
+  } else if (n_acelerador >= a0_high_value) {
+    return ;
   }
   return n_acelerador;
 }

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -265,16 +265,6 @@ void estableceCrucero() {
 	}
 }
 
-float nivelaAcelerador(float &n_acelerador) {
-	// Nivelamos los valores para que no salgan del rango de máximo/mínimo.
-	if (n_acelerador <= a0_min_value) {
-		n_acelerador = a0_min_value;
-	} else if (n_acelerador >= a0_max_value) {
-		n_acelerador = a0_max_value;
-	}
-	return n_acelerador;
-}
-
 float leeAcelerador() {
 	float cl_acelerador = 0;
 
@@ -285,6 +275,17 @@ float leeAcelerador() {
 
 	cl_acelerador = cl_acelerador / 30;
 	return nivelaAcelerador(cl_acelerador);
+}
+
+
+float nivelaAcelerador(float n_acelerador) {
+  // Nivelamos los valores para que no salgan del rango de máximo/mínimo.
+  if (n_acelerador <= a0_min_value) {
+    return a0_min_value;
+  } else if (n_acelerador >= a0_max_value) {
+    return a0_max_value;
+  }
+  return n_acelerador;
 }
 
 void mandaAcelerador() {

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -140,9 +140,6 @@ const float v_max_acelerador = 3.90; // TODO eliminar valor en voltios y utiliza
 // Voltaje mínimo de acelerador en reposo.
 const float voltaje_minimo = 0.85; // TODO eliminar valor en voltios y utilizar a0_min_value
 
-// Valor mínimo del acelerador para evitar fallos por picos.
-const float minimo_acelerador = 1.15; // TODO eliminar valor en voltios y utilizar a0_low_value
-
 // 6 km/h en el acelerador.
 // -------------- const float sixkmh_acelerador = 2.19; // TODO eliminar valor en voltios y utilizar a0_6km_value
 
@@ -266,13 +263,11 @@ float voltiosEnDac(float volts) {
 	return (4096 / 5) * volts;
 }
 
-void estableceCrucero() {
-	// Pasa a escala de 0-5 voltios.
-	v_acelerador = aceleradorEnVoltios(v_acelerador);
+void estableceCrucero(float throtle) {
 
-	if (v_acelerador > minimo_acelerador) {
-		v_crucero_ac = v_acelerador;
-		v_crucero = v_crucero_ac;
+	if (throtle > a0_low_value) {
+		v_crucero_ac = aceleradorEnVoltios(throtle);
+		v_crucero = aceleradorEnVoltios(throtle);
 	}
 }
 
@@ -359,7 +354,7 @@ void ayudaArranque() {
 	}
 
 	// Dejamos de asistir en el DAC.
-	dac.setVoltage(voltiosEnDac(voltaje_minimo),false);
+	dac.setVoltage(aceleradorEnDac(a0_min_value),false);
 	// Cortamos crucero.
 	v_crucero = voltaje_minimo;
 }
@@ -447,7 +442,7 @@ void loop() {
 	// Establecemos un retardo para detectar la caída de voltaje en el crucero.
 	if (tiempo > tcrucero + 125) { // Si ha pasado 125 ms.
 		tcrucero = millis(); // Actualiza tiempo actual.
-		estableceCrucero();
+		estableceCrucero(v_acelerador);
 	}
 
 	if (tiempo > tcadencia + (unsigned long) tiempo_cadencia) {

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -249,12 +249,19 @@ void pedal() {
 }
 
 
+// Pasamos de escala acelerador -> Voltios
 float aceleradorEnVoltios(float throttle) {
 	return throttle * 5 / 1023;
 }
 
+// Pasamos de escala acelerador -> DAC
 float aceleradorEnDac(float throttle) {
-	return (4096 / 5) * throttle;
+  return throttle * 4096 / 1023;
+}
+
+// Pasamos de escala voltios -> DAC
+float voltiosEnDac(float volts) {
+	return (4096 / 5) * volts;
 }
 
 void estableceCrucero() {
@@ -317,7 +324,7 @@ void mandaAcelerador() {
 	if (nivel_aceleracion != bkp_voltaje) {
 		bkp_voltaje = nivel_aceleracion;
 		// Ajusta el voltaje a valor entre 0-4096 (Resolución del DAC).
-		uint32_t valor = aceleradorEnDac(nivel_aceleracion);
+		uint32_t valor = voltiosEnDac(nivel_aceleracion);
 		// Fija voltaje en DAC.
 		dac.setVoltage(valor,false);
 	}  
@@ -349,11 +356,11 @@ void ayudaArranque() {
 		// No queremos iniciar un progresivo si empezamos a pedalear con el acelerador accionado.
 		contador_retardo_inicio_progresivo++;
 		// Mandamos al DAC 6 km/h.
-		dac.setVoltage(aceleradorEnDac(sixkmh_acelerador),false);
+		dac.setVoltage(voltiosEnDac(sixkmh_acelerador),false);
 	}
 
 	// Dejamos de asistir en el DAC.
-	dac.setVoltage(aceleradorEnDac(voltaje_minimo),false);
+	dac.setVoltage(voltiosEnDac(voltaje_minimo),false);
 	// Cortamos crucero.
 	v_crucero = voltaje_minimo;
 }

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -134,6 +134,7 @@ const int tiempo_cadencia = 250;
 // Valores mínimos y máximos del acelerador leídos por el pin A0.
 float a0_valor_reposo = 190.0; // Valor por defecto, al inicializar, lee el valor real del acelerador.
 const float a0_valor_minimo = 235.0;  // 1.15
+const float a0_valor_suave = 410.0;  // 2.00
 const float a0_valor_6kmh = 450.0;  // 2.19
 const float a0_valor_medio = 550.0;  // 2.68
 const float a0_valor_alto = 798.0; // 3.90
@@ -273,9 +274,9 @@ void mandaAcelerador() {
 		v_crucero = a0_valor_reposo;	
 	}	
 
-	// Evita salidas demasiado bruscas. // TODO 2.0 - > 2
-	if (nivel_inicial_progresivo > 410) {	
-		nivel_inicial_progresivo = a0_valor_6kmh;
+	// Evita salidas demasiado bruscas.
+	if (nivel_inicial_progresivo > a0_valor_suave) {	
+		nivel_inicial_progresivo = a0_valor_suave;
 	}
 
 	if (modo_crucero == true) {

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -281,10 +281,10 @@ float leeAcelerador() {
 
 float nivelaAcelerador(float n_acelerador) {
   // Nivelamos los valores para que no salgan del rango de máximo/mínimo.
-  if (n_acelerador <= a0_min_value) {
+  if (n_acelerador < a0_min_value) {
     return a0_min_value;
-  } else if (n_acelerador >= a0_high_value) {
-    return ;
+  } else if (n_acelerador > a0_high_value) {
+    return a0_high_value;
   }
   return n_acelerador;
 }

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -149,7 +149,8 @@ float a0_min_value = 190.0; // Valor por defecto, al inicializar, lee el valor r
 const float a0_low_value = 235.0;  // 1.15
 const float a0_6km_value = 450.0;  // 2.19
 const float a0_med_value = 550.0;  // 2.68
-const float a0_high_value = 847.0; // 4.13
+const float a0_high_value = 798.0; // 3.90
+const float a0_max_value = 847.0;  // 4.13
 
 // Variables para millis().
 unsigned long tcadencia;
@@ -269,24 +270,20 @@ void estableceCrucero() {
 float leeAcelerador() {
 	float cl_acelerador = 0;
 
-	// Leemos nivel de acelerador.
+	// Leemos nivel de acelerador tomando 30 medidas.
 	for (int f=1; f <= 30; f++) {
 		cl_acelerador = cl_acelerador + analogRead(pin_acelerador);
 	}
 
 	cl_acelerador = cl_acelerador / 30;
-	return nivelaAcelerador(cl_acelerador);
-}
 
-
-float nivelaAcelerador(float n_acelerador) {
-  // Nivelamos los valores para que no salgan del rango de máximo/mínimo.
-  if (n_acelerador < a0_min_value) {
+  // Nivelamos los valores de la media para que no se salgan del rango de máximo/mínimo.
+  if (cl_acelerador < a0_min_value) {
     return a0_min_value;
-  } else if (n_acelerador > a0_high_value) {
-    return a0_high_value;
+  } else if (cl_acelerador > a0_max_value) {
+    return a0_max_value;
   }
-  return n_acelerador;
+  return cl_acelerador;
 }
 
 void mandaAcelerador() {


### PR DESCRIPTION
Actualizado código para realizar cálculos con valores de sensor de acelerador y evitar trabajar con voltios.
Queda pendiente revisar las variales de cálculos, para trabajar con enteros en vez de con floats, ya que los valores del acelerador van a ser siempre enteros leidos por la entrada analógica.