### PR TITLE
Control de fijación y salida de crucero.

### DIFF
--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -263,7 +263,7 @@ void estableceCrucero(float vl_acelerador) {
     }
   }else{ 
     // El crucero se actualiza mientras se esté pedaleando con la lectura del acelerador siempre que esta sea superior al valor de referencia.
-    if (vl_acelerador > a0_valor_minimo && p_pulsos > 0) {
+    if (vl_acelerador > valor_fija_crucero && p_pulsos > 0) {
       v_crucero = vl_acelerador;
       crucero_actualizado = true;
     } else if (crucero_actualizado && v_crucero > valor_fija_crucero && // Si el crucero se ha actualizado por encima del nivel_medio de potencia                      

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -259,14 +259,8 @@ float aceleradorEnDac(float vl_acelerador) {
   return vl_acelerador * 4096 / 1023;
 }
 
-void estableceCrucero(float vl_acelerador) {
-  
-  if(crucero_fijado){
-    // Si se supera el valor de crucero con el acelerador, se desactiva el crucero.
-    //if(v_crucero <= vl_acelerador) {
-    //  anulaCrucero();
-    //}
-  }else{ 
+void estableceCrucero(float vl_acelerador) { 
+  if(!crucero_fijado){
     // El crucero se actualiza mientras se esté pedaleando con la lectura del acelerador siempre que esta sea superior al valor de referencia.
     if (vl_acelerador > a0_valor_minimo && p_pulsos > 0) {
     
@@ -275,15 +269,14 @@ void estableceCrucero(float vl_acelerador) {
       
     // Si el crucero se ha actualizado por encima del nivel_medio de potencia y si detecta que el acelerador está por debajo del valor mínimo. Fija el crucero.
     } else if (crucero_actualizado && 
-               v_crucero > valor_fija_crucero &&                       
+               v_crucero > valor_fija_crucero && 
                vl_acelerador <= a0_valor_reposo) {
-                  
+
       crucero_actualizado = false;
       crucero_fijado = true;
       repeatTones(tono_inicial, 1, 3000, 190, 1);
     }
   }
-  
 }
 
 // Calcula si el valor se encuantra entre el rango de valores con tolerancia calculados con el valor2.

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -201,7 +201,6 @@ volatile int p_pulsos = 0;
 //======= Variables fijaCrucero =======================================
 float prev_v_acelerador = a0_valor_reposo; // Variable para calcular el valor medio de medidas del acelerador para selección del crucero.
 
-
 //======= FUNCIONES DE TONOS ===========================================
 
 //================== TONES ==================
@@ -260,18 +259,16 @@ float aceleradorEnDac(float vl_acelerador) {
   return vl_acelerador * 4096 / 1023;
 }
 
-int cancelacrucerott = 0;
 void estableceCrucero(float vl_acelerador) {
   
   if(crucero_fijado){
     // Si se supera el valor de crucero con el acelerador, se desactiva el crucero.
-    if(v_crucero <= vl_acelerador && cancelacrucerott++ > 5) {
-      anulaCrucero();
-    }
+    //if(v_crucero <= vl_acelerador) {
+    //  anulaCrucero();
+    //}
   }else{ 
-    cancelacrucerott=0;
     // El crucero se actualiza mientras se esté pedaleando con la lectura del acelerador siempre que esta sea superior al valor de referencia.
-    if (vl_acelerador > valor_fija_crucero && p_pulsos > 0) {
+    if (vl_acelerador > a0_valor_minimo && p_pulsos > 0) {
     
       v_crucero = vl_acelerador;
       crucero_actualizado = true;
@@ -279,7 +276,7 @@ void estableceCrucero(float vl_acelerador) {
     // Si el crucero se ha actualizado por encima del nivel_medio de potencia y si detecta que el acelerador está por debajo del valor mínimo. Fija el crucero.
     } else if (crucero_actualizado && 
                v_crucero > valor_fija_crucero &&                       
-               vl_acelerador <= a0_valor_minimo) {
+               vl_acelerador <= a0_valor_reposo) {
                   
       crucero_actualizado = false;
       crucero_fijado = true;

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -303,13 +303,7 @@ float leeAcelerador() {
 }
 
 void mandaAcelerador() {
-/*
-  // TODO Esto ya no vale con la variable crucero_fijado ya que se deja de reestablecer el valor de v_crucero constantemente por lo que la medida siempre será la fijada.
-  // Anula crucero por debajo del nivel inicial del progresivo.
-  if (v_crucero < nivel_inicial_progresivo) {   
-    anulaCrucero();
-  }
-*/
+
   // Evita salidas demasiado bruscas. 
   if (nivel_inicial_progresivo > a0_valor_suave) {  
     nivel_inicial_progresivo = a0_valor_suave;  

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -189,6 +189,7 @@ int pulsos = 0;
 boolean ayuda_salida = false;
 
 // Variable que almacena el estado de notificación de fijar crucero.
+float valor_fija_crucero = a0_valor_medio; // Valor en el que se empieza a fijar crucero. Cambiar si se quiere fijar crucero desde potencias inferiores.
 boolean crucero_actualizado = false;
 boolean crucero_fijado = false;
 
@@ -257,22 +258,22 @@ float aceleradorEnDac(float vl_acelerador) {
 void estableceCrucero(float vl_acelerador) {
   
   if(crucero_fijado){
-    //if(v_crucero<=vl_acelerador){ // Si se supera el valor de crucero con el acelerador, se desactiva el crucero.
-    if(comparaConTolerancia(vl_acelerador, v_crucero, 20)){
-      anulaCrucero();
+    if(v_crucero<=vl_acelerador){ // Si se supera el valor de crucero con el acelerador, se desactiva el crucero.
+      anulaCrucero(false);
     }
   }else{ 
     // El crucero se actualiza mientras se esté pedaleando con la lectura del acelerador siempre que esta sea superior al valor de referencia.
     if (vl_acelerador > a0_valor_minimo && p_pulsos > 0) {
       v_crucero = vl_acelerador;
       crucero_actualizado = true;
-    // Si el acelerador está al mínimo en la siguiente vuelta, se emite un tono de aviso para fijar el crucero.
-    } else if (vl_acelerador <= a0_valor_minimo && crucero_actualizado) {
+    } else if (crucero_actualizado && v_crucero > valor_fija_crucero && // Si el crucero se ha actualizado por encima del nivel_medio de potencia                      
+                vl_acelerador <= a0_valor_minimo){  // y si detecta que el acelerador está por debajo del valor mínimo. Fija el crucero.
       crucero_actualizado = false;
       crucero_fijado = true;
       repeatTones(tono_inicial, 1, 3000, 190, 1);
-    }
+    }    
   }
+  
 }
 
 // Calcula si el valor se encuantra entre el rango de valores con tolerancia calculados con el valor2.
@@ -348,15 +349,17 @@ void freno() {
   // Anular la variable freno_anula_crucero ya que debería ser necesario salir del crucero al tocar el freno sin dar opción a configuración.
   //if (crucero_fijado) {
   if (crucero_fijado && freno_anula_crucero) {
-    anulaCrucero();
+    anulaCrucero(true);
   }
 }
 
-void anulaCrucero(){
+void anulaCrucero(boolean freno){
   v_crucero = a0_valor_corte;
   crucero_actualizado = false;
   crucero_fijado = false;
-  repeatTones(tono_inicial, 1, 2000, 190, 100);
+  if(!freno){
+    repeatTones(tono_inicial, 1, 2000, 190, 100);
+  }
 }
 
 void ayudaArranque() {

--- a/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
+++ b/Con_Acelerador_DAC_Millis_ProgNL_6kmh/Con_Acelerador_DAC_Millis_ProgNL_6kmh.ino
@@ -256,12 +256,17 @@ float aceleradorEnDac(float vl_acelerador) {
 
 void estableceCrucero(float vl_acelerador) {
   
-  if(!crucero_fijado){
+  if(crucero_fijado){
+    //if(v_crucero<=vl_acelerador){ // Si se supera el valor de crucero con el acelerador, se desactiva el crucero.
+    if(comparaConTolerancia(vl_acelerador, v_crucero, 20)){
+      anulaCrucero();
+    }
+  }else{ 
     // El crucero se actualiza mientras se esté pedaleando con la lectura del acelerador siempre que esta sea superior al valor de referencia.
     if (vl_acelerador > a0_valor_minimo && p_pulsos > 0) {
       v_crucero = vl_acelerador;
       crucero_actualizado = true;
-    // Si el acelerador está al mínimo en la siguiente vuelta, se emite un tono de aviso.
+    // Si el acelerador está al mínimo en la siguiente vuelta, se emite un tono de aviso para fijar el crucero.
     } else if (vl_acelerador <= a0_valor_minimo && crucero_actualizado) {
       crucero_actualizado = false;
       crucero_fijado = true;
@@ -349,8 +354,9 @@ void freno() {
 
 void anulaCrucero(){
   v_crucero = a0_valor_corte;
+  crucero_actualizado = false;
   crucero_fijado = false;
-  repeatTones(tono_inicial, 3, 3000, 190, 1);
+  repeatTones(tono_inicial, 1, 2000, 190, 100);
 }
 
 void ayudaArranque() {


### PR DESCRIPTION
He bloqueado el método de fijar crucero para que una vez fijado no sea operativo hasta liberarlo pulsando el freno.
Queda pendiente ver cómo volver a activar el desbloqueo del crucero por medio de la interacción con el acelerador. 
Se ha añadido el tono de salida de crucero.

El merge está un poco desparramado porque utilizamos distintos editores y uno usa tabuladores y el otro espacios. :(